### PR TITLE
Escaped '<' and '>' when "upgrading" to Rich Text

### DIFF
--- a/src/GAS/services/merge-template-service.js
+++ b/src/GAS/services/merge-template-service.js
@@ -177,9 +177,6 @@ var MergeTemplateService = {
       var config;
       try {
         config = JSON.parse(value);
-        // set default value for version if it doesn't exist.
-        if (!config.version)
-          config.version = "1.0.0";
         MergeTemplateService.validate(config);
         return config;
       }

--- a/src/client/js/controllers/standard-mail-handler.js
+++ b/src/client/js/controllers/standard-mail-handler.js
@@ -132,7 +132,13 @@ var StandardMailHandler = function (parent, serviceFactory) {
       bcc: updateConfig.mergeData.data.bcc
     });
     cardRepository[CardNames.subject].setValue(updateConfig.mergeData.data.subject);
-    cardRepository[CardNames.body].setValue(updateConfig.mergeData.data.body);
+
+    if (updateConfig.version === "1.0.0") {
+      // one time fix for "upgrading" to rich text version
+      cardRepository[CardNames.body].setValue(updateConfig.mergeData.data.body.replace(/\</g, '&lt;').replace(/\>/g, '&gt;'));
+    } else {    
+      cardRepository[CardNames.body].setValue(updateConfig.mergeData.data.body);
+    }
     cardRepository[CardNames.repeater].setValue(updateConfig.mergeData.repeater);
 
     if (updateConfig.mergeData.conditional != null) {

--- a/src/client/js/data/merge-template/merge-template.js
+++ b/src/client/js/data/merge-template/merge-template.js
@@ -37,6 +37,7 @@ var MergeTemplate = function(config) {
   var self = this;
   var createdBy = 'Unknown user';
   var createdDatetime;
+  var version;
   var id = ID();
 
   //***** Private Methods *****//
@@ -78,6 +79,12 @@ var MergeTemplate = function(config) {
 
     if (config.mergeRepeater != null) {
       repeater = new MergeRepeater(config.mergeRepeater);
+    }
+
+    if (config.version) {
+      version = config.version;
+    } else {
+      version = '1.0.0';
     }
   };
 
@@ -127,6 +134,7 @@ var MergeTemplate = function(config) {
       mergeData: data.toConfig(),
       createdBy: createdBy,
       createdDatetime: createdDatetime,
+      version: version,
       id: id
     };
   };


### PR DESCRIPTION
Fixes issue #1 of our Mailman post-release test steps doc.