### PR TITLE
Bug fix when the user use mailman-2.0 for the first time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.vs/
 .DS_Store
 .vscode-janus-debug
+src/Mailman.Server/appsettings.Development.json

--- a/src/Mailman.Server/appsettings.Development.json
+++ b/src/Mailman.Server/appsettings.Development.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    }
-  }
-}

--- a/src/Mailman.Services/Google/SheetsServiceImpl.cs
+++ b/src/Mailman.Services/Google/SheetsServiceImpl.cs
@@ -70,12 +70,17 @@ namespace Mailman.Services.Google
                 try { response = await request.ExecuteAsync(); }
                 catch (GoogleApiException gex)
                 {
-                    throw new SheetNotFoundException("Sheet $spreadsheetId not found", gex);
+                    _logger.Error("Sheet $spreadsheetId not found", gex);
+                    // throw new SheetNotFoundException("Sheet $spreadsheetId not found", gex);
+                    IList<IList<object>> emptyValues = new List<IList<object>>();
+                    return emptyValues;
                 }
                 catch (Exception err)
                 {
                     _logger.Error(err, "Unable to read from Google Sheets: {ErrorMessage}", err.Message);
-                    throw new ReadGoogleSheetsException("Unable to read from Google Sheets", err);
+                    //throw new ReadGoogleSheetsException("Unable to read from Google Sheets", err);
+                    IList<IList<object>> emptyValues = new List<IList<object>>();
+                    return emptyValues;
                 }
 
                 returnValue = response.Values;


### PR DESCRIPTION
A very small bug fix.

If the spreadsheet couldn't be found in the database and it doesn't have an mm-config file, the mailman-2.0 will create a new entry in the database with an empty merge templates list.
